### PR TITLE
Fix GitHub Actions push permissions

### DIFF
--- a/.github/workflows/update_cvdr.yml
+++ b/.github/workflows/update_cvdr.yml
@@ -12,6 +12,8 @@ on:
 
 jobs:
   crawl_and_upload:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     timeout-minutes: 355 # Set timeout slightly less than the 6-hour (360 min) limit
 


### PR DESCRIPTION
## Summary
- allow `GITHUB_TOKEN` to push updates from workflow

## Testing
- `python -m py_compile cvdr_crawler.py`
- `python cvdr_crawler.py` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_68624d9977088329866416cd1095e1c6